### PR TITLE
PR: Enlever les doublons dans les données piézo du RSESQ

### DIFF
--- a/rsesq-data/readers/read_mddelcc_rses.py
+++ b/rsesq-data/readers/read_mddelcc_rses.py
@@ -106,9 +106,16 @@ def get_wldata_from_xls(url):
         wlvl = np.array(ws.col_values(1, start_rowx=row_idx)).astype(float)
         wtemp = np.array(ws.col_values(2, start_rowx=row_idx)).astype(float)
 
-        elevation = find_float_from_str(ws.cell_value(2, 2), ',')
+    # Remove duplicates in time series and save in a dataframe
+    indexes = np.digitize(np.unique(time), time, right=True)
 
-        return (elevation, time, wlvl, wtemp)
+    df = {}
+    df['Elevation'] = find_float_from_str(ws.cell_value(2, 2), ',')
+    df['Time'] = time[indexes]
+    df['Water Level'] = wlvl[indexes]
+    df['Temperature'] = wtemp[indexes]
+
+    return df
 
 
 # ---- API

--- a/rsesq-data/readers/read_mddelcc_rses.py
+++ b/rsesq-data/readers/read_mddelcc_rses.py
@@ -228,3 +228,4 @@ class MDDELCC_RSESQ_Reader(AbstractReader):
 if __name__ == "__main__":
     reader = MDDELCC_RSESQ_Reader()
     reader.save_station_to_csv('01160002', 'test.csv')
+    data = reader.fetch_station_wldata('02257001')

--- a/rsesq-data/readers/read_mddelcc_rses.py
+++ b/rsesq-data/readers/read_mddelcc_rses.py
@@ -131,11 +131,15 @@ class MDDELCC_RSESQ_Reader(AbstractReader):
     def __getitem__(self, key):
         return self._db[key]
 
+    # ---- Utility functions
+
     def stations(self):
         return self._db.values()
 
     def station_ids(self):
         return list(self._db.keys())
+
+    # ---- Load and fetch database
 
     def load_database(self):
         try:
@@ -158,6 +162,7 @@ class MDDELCC_RSESQ_Reader(AbstractReader):
         station['Time'] = time
         station['Water level'] = wlvl
         station['Temperature'] = wtemp
+    # ---- Fetch data
 
         np.save(self.DATABASE_FILEPATH, self._db)
 
@@ -171,6 +176,8 @@ class MDDELCC_RSESQ_Reader(AbstractReader):
         station = self._db[station_id]
         if station['url data'] not in [None, '', b'']:
             urlretrieve(station['url data'], filepath)
+
+    # ---- Save to file
 
     def save_station_to_hdf5(self, station_id, filepath):
         pass

--- a/rsesq-data/readers/read_mddelcc_rses.py
+++ b/rsesq-data/readers/read_mddelcc_rses.py
@@ -152,19 +152,16 @@ class MDDELCC_RSESQ_Reader(AbstractReader):
         self._db = read_xml_datatable(url)
         np.save(self.DATABASE_FILEPATH, self._db)
 
-    def fetch_station_wldata(self, station_id):
-        station = self._db[station_id]
-        if station['url data'] in [None, '', b'']:
-            return
-
-        elevation, time, wlvl, wtemp = get_wldata_from_xls(station['url data'])
-        station['Elevation'] = elevation
-        station['Time'] = time
-        station['Water level'] = wlvl
-        station['Temperature'] = wtemp
     # ---- Fetch data
 
-        np.save(self.DATABASE_FILEPATH, self._db)
+    def fetch_station_wldata(self, sid):
+        url = self._db[sid]['url data']
+        if url in [None, '', b'']:
+            return
+        else:
+            self._db[sid].update(get_wldata_from_xls(url))
+            np.save(self.DATABASE_FILEPATH, self._db)
+            return self._db[sid]
 
     def dwnld_raw_xls_datafile(self, station_id, filepath):
         # Create the destination directory if it doesn't exist.


### PR DESCRIPTION
Fixes #2 

----

Il y a des doublons dans les données de certaines stations piézométriques. Par exemple pour la station `Saint-Antonin (02257001)`, il y avait deux entrées de données pour le 22/05/1980.

Pour régler ce problème, lorsqu'il y a plus d'une entrée de données pour une date donnée, seule la première ligne est conservée lors de la lecture des données à partir des fichiers Excels téléchargés du MDDELCC.

Cette PR permet également d'optimiser le processus de lecture et de sauvegarder des données en format csv.